### PR TITLE
javascript base request fix for using plain js or axios request

### DIFF
--- a/javascript/base_request.js
+++ b/javascript/base_request.js
@@ -1,6 +1,6 @@
 const args = process.argv.slice(2) // Loads either plain JS or axios base request based on CLI flag from package.json
 
-const isAxios = args[0] == 'axios' || !args.length
+const isAxios = args[0] == 'axios'
 const baseRequest = isAxios ? require('./base_request_axios.js') : require('./base_request_javascript.js')
 
 module.exports = { baseRequest }


### PR DESCRIPTION
Remove args length check which was true when no argument provided. This was causing the condition to always be true and use Axios base request.