### PR TITLE
FILE-2263: end-to-end example of EIN tax id checkout in Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ php/composer.lock
 php/downloads/**
 php/documents/
 python/__pycache__/**
+python/examples/__pycache__/**
 python/documents/
 csharp/.env
 csharp/.vs/**

--- a/python/README.md
+++ b/python/README.md
@@ -14,4 +14,8 @@ The Python examples read in configurable properties from a shared `.env` file at
 - `pip3 install python-dotenv`
 
 ## Getting Started
-1. `python3 examples/<script-filename>` (see `examples` directory for example options)
+1. `python3 examples/<script-filename> <standalone-arg>` (see `examples` directory for example options)
+	- The `<standalone-arg>` runs the script in a standalone example mode, the argument can be any value
+2. `python3 examples/end-to-end/<script-filename>` 
+	- More complex examples of a series of requests that depend upon each other 
+	- These examples reuse the request classes from the `/examples/` folder 

--- a/python/examples/delete_callbacks.py
+++ b/python/examples/delete_callbacks.py
@@ -18,9 +18,11 @@ class DeleteCallbacksRequest(BaseRequest):
     def delete_callbacks(self, callback_id):
         return self.make_request('DELETE', f'/callbacks/{callback_id}')
 
-callback_id = config['CALLBACK_ID']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    callback_id = config['CALLBACK_ID']
 
-request = DeleteCallbacksRequest()
-response = request.delete_callbacks(callback_id)
+    request = DeleteCallbacksRequest()
+    response = request.delete_callbacks(callback_id)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/delete_payment_methods.py
+++ b/python/examples/delete_payment_methods.py
@@ -18,9 +18,11 @@ class DeletePaymentMethodsRequest(BaseRequest):
     def delete_payment_methods(self, payment_method_id):
         return self.make_request('DELETE', f'/payment-methods/{payment_method_id}')
 
-payment_method_id = config['PAYMENT_METHOD_ID']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    payment_method_id = config['PAYMENT_METHOD_ID']
 
-request = DeletePaymentMethodsRequest()
-response = request.delete_payment_methods(payment_method_id)
+    request = DeletePaymentMethodsRequest()
+    response = request.delete_payment_methods(payment_method_id)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/delete_shopping_cart.py
+++ b/python/examples/delete_shopping_cart.py
@@ -22,10 +22,12 @@ class DeleteShoppingCartRequest(BaseRequest):
         }
         return self.make_request('DELETE', '/shopping-cart', params=params)
 
-company_id = config['COMPANY_ID']
-item_id = config['SHOPPING_CART_ITEM_ID']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    company_id = config['COMPANY_ID']
+    item_id = config['SHOPPING_CART_ITEM_ID']
 
-request = DeleteShoppingCartRequest()
-response = request.delete_shopping_cart(company_id, item_id)
+    request = DeleteShoppingCartRequest()
+    response = request.delete_shopping_cart(company_id, item_id)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/end-to-end/ein_tax_id_checkout.py
+++ b/python/examples/end-to-end/ein_tax_id_checkout.py
@@ -1,0 +1,168 @@
+import pprint
+import os
+import sys
+import json
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from request import BaseRequest
+from dotenv import dotenv_values
+
+from get_filing_products_offerings import GetFilingProductsOfferingsRequest
+from get_filing_methods import GetFilingMethodsRequest
+from post_shopping_cart import PostShoppingCartRequest
+from post_payment_methods import PostPaymentMethodsRequest
+from get_payment_methods import GetPaymentMethodsRequest
+from get_shopping_cart import GetShoppingCartRequest
+from post_shopping_cart_checkout import PostShoppingCartCheckoutRequest
+from get_invoice import GetInvoiceRequest
+from get_filing_methods_schemas import GetFilingMethodsSchemasRequest
+from get_order_items_requiring_attention import GetOrderItemsRequiringAttentionRequest
+from post_order_items_requiring_attention import PostOrderItemsRequiringAttentionRequest
+
+config = dotenv_values()
+
+# Example of end-to-end 'EIN Tax Id' filing product shopping cart checkout
+#
+#     High-level steps:
+#     1. Get the filing product id from GET /filing-products/offerings
+#     2. Get the filing method id from GET /filing-methods
+#     3. Add the filing to cart with POST /shopping-cart
+#     4. Add card information as payment method with POST /payment-methods
+#     5. Get payment method id from GET /payment-methods
+#     6. Get shopping cart item id from GET /shopping-cart
+#     7. Perform shopping cart checkout 
+#     8. Check invoice status from GET /invoices/:invoice_id
+#     # Optionally, skip these steps by providing 'form_data' parameter in step #3
+#     9. Get filing form schema from GET /filing-methods/schemas
+#     10. Get id of order item requiring client attention GET /order-items/requiring-attention
+#     11. Add form_data to order item with POST /order-items
+
+COMPANY_ID = config['COMPANY_ID']
+JURISDICTION = config['JURISDICTION']
+
+# Step 1: Get the filing product id from GET /filing-products/offerings
+
+request = GetFilingProductsOfferingsRequest()
+response = request.get_filing_products_offerings(COMPANY_ID, JURISDICTION)
+
+filing_products = [product for product in response['result'] if product['filing_name'] == 'tax id']
+product_id = filing_products[0]['id']
+
+pprint.pprint(f'filing product id: {product_id}')
+
+# Step 2: Get the filing method id from GET /filing-methods
+
+request = GetFilingMethodsRequest()
+response = request.get_filing_methods(COMPANY_ID, product_id, JURISDICTION)
+
+filing_methods = [method for method in response['result'] if method['name'] == 'Standard' and method['type'] == 'online']
+filing_method_id = filing_methods[0]['id']
+
+pprint.pprint(f'filing method id: {filing_method_id}')
+
+# Step 3: Add the filing to cart with POST /shopping-cart
+
+request = PostShoppingCartRequest()
+response = request.post_shopping_cart(COMPANY_ID, product_id, filing_method_id, 1)
+success = response['success']
+
+pprint.pprint(f'Add to cart: {success}')
+
+# Step 4: Add card information as payment method with POST /payment-methods
+
+payment_card_info = { 
+		'number': '4000056655665556',
+		'exp_month': '05',
+		'exp_year': '2029',
+		'cvc': '888',
+		'first_name': 'Example',
+		'last_name': 'Test',
+		'billing_address': {
+			"city": "New York",
+			"state": "NY",
+			"zip": "10463",
+			"country": "US",
+			"address1": "1234 Seasame Street",
+			"address2": None
+		}
+	}
+request = PostPaymentMethodsRequest()
+response = request.post_payment_methods(payment_card_info)
+
+pprint.pprint(f'Add payment method: {response}')
+
+# Step 5: Get payment method id from GET /payment-methods
+
+request = GetPaymentMethodsRequest()
+response = request.get_payment_methods()
+
+payment_methods = [method for method in response['result'] 
+					if method['last4'] == '5556' and method['exp_month'] == 5 and method['exp_year'] == 2029 ]
+payment_method_id = payment_methods[0]['id']
+
+pprint.pprint(f'payment method id: {payment_method_id}')
+
+# Step 6: Get shopping cart item id from GET /shopping-cart
+
+request = GetShoppingCartRequest()
+response = request.get_shopping_cart([COMPANY_ID])
+
+shopping_cart_items = [item for item in response['result'] 
+	if item['product_id'] == product_id and
+	item['product_option_id'] == filing_method_id and
+	item['company_id'] == COMPANY_ID and
+	item['title'] == 'Tax id filing service - Standard'
+]
+
+shopping_cart_item_id = shopping_cart_items[0]['id']
+
+pprint.pprint(f'shopping cart item id: {shopping_cart_item_id}')
+
+# Step 7: Perform shopping cart checkout
+
+request = PostShoppingCartCheckoutRequest()
+response = request.post_checkout(COMPANY_ID, shopping_cart_item_id, payment_method_id)
+checkout_invoice_id = response['invoice_ids'][0]
+
+pprint.pprint(f'invoice id: {checkout_invoice_id}')
+
+# Step 8: Check invoice status from GET /invoices/:invoice_id
+
+request = GetInvoiceRequest()
+response = request.get_invoice(checkout_invoice_id)
+invoice_status = response['result']['status']
+
+pprint.pprint(f'invoice status: {invoice_status}')
+
+# Step 9: Get filing form schema from GET /filing-methods/schemas
+
+request = GetFilingMethodsSchemasRequest()
+response = request.get_filing_methods_schemas(COMPANY_ID, filing_method_id)
+
+pprint.pprint(f'form data schema: {response}')
+
+# Step 10: Get id of order item requiring client attention GET /order-items/requiring-attention
+
+request = GetOrderItemsRequiringAttentionRequest()
+response = request.get_requiring_attention([COMPANY_ID])
+order_items = [item for item in response['result'] 
+	if item['name'] == 'Standard Federal EIN - Tax Id filing' and
+	item['company_id'] == COMPANY_ID
+]
+order_item_id = order_items[0]['id']
+
+pprint.pprint(f'order item requiring attention: {order_item_id}')
+
+# Step 11: Add form_data to order item with POST /order-items
+
+cwd = os.getcwd();
+file_path = f"{cwd}/../data/form_data_ein_tax_id.json";
+with open(file_path, 'r') as file:
+    form_data = json.load(file)
+    pprint.pprint(f'form data: {form_data}')
+    request = PostOrderItemsRequiringAttentionRequest()
+    response = request.post_requring_attention(COMPANY_ID, order_item_id, form_data)
+    pprint.pprint(f'Added form data to order item: {response}')
+

--- a/python/examples/get_account.py
+++ b/python/examples/get_account.py
@@ -16,7 +16,9 @@ class GetAccountRequest(BaseRequest):
         path = "/account"
         return self.make_request("GET", path)
 
-get_account_request = GetAccountRequest()
-account = get_account_request.get_account()
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    get_account_request = GetAccountRequest()
+    account = get_account_request.get_account()
 
-pprint.pprint(account)
+    pprint.pprint(account)

--- a/python/examples/get_account_dashpanel.py
+++ b/python/examples/get_account_dashpanel.py
@@ -16,7 +16,9 @@ class GetAccountDashPanelRequest(BaseRequest):
         path = "/account/dashpanel"
         return self.make_request("GET", path)
 
-request = GetAccountDashPanelRequest()
-account = request.get_account_dashpanel()
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    request = GetAccountDashPanelRequest()
+    account = request.get_account_dashpanel()
 
-pprint.pprint(account)
+    pprint.pprint(account)

--- a/python/examples/get_callbacks.py
+++ b/python/examples/get_callbacks.py
@@ -16,7 +16,9 @@ class GetCallbacksRequest(BaseRequest):
         path = "/callbacks"
         return self.make_request("GET", path)
 
-get_callbacks_request = GetCallbacksRequest()
-callbacks = get_callbacks_request.get_callbacks()
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    get_callbacks_request = GetCallbacksRequest()
+    callbacks = get_callbacks_request.get_callbacks()
 
-pprint.pprint(callbacks)
+    pprint.pprint(callbacks)

--- a/python/examples/get_companies.py
+++ b/python/examples/get_companies.py
@@ -19,7 +19,9 @@ class GetCompaniesRequest(BaseRequest):
         path = "/companies"
         return self.make_request("GET", path)
 
-get_companies_request = GetCompaniesRequest()
-companies = get_companies_request.get_companies()
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    get_companies_request = GetCompaniesRequest()
+    companies = get_companies_request.get_companies()
 
-pprint.pprint(companies)
+    pprint.pprint(companies)

--- a/python/examples/get_company.py
+++ b/python/examples/get_company.py
@@ -19,9 +19,11 @@ class GetCompanyRequest(BaseRequest):
         path = f"/companies/{company_id}"
         return self.make_request("GET", path)
 
-company_id = config['COMPANY_ID']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    company_id = config['COMPANY_ID']
 
-get_company_request = GetCompanyRequest()
-company = get_company_request.get_company()
+    get_company_request = GetCompanyRequest()
+    company = get_company_request.get_company()
 
-pprint.pprint(company)
+    pprint.pprint(company)

--- a/python/examples/get_compliance_events.py
+++ b/python/examples/get_compliance_events.py
@@ -20,10 +20,12 @@ class ComplianceEventsRequest(BaseRequest):
         params = { 'start_date': start_date, 'end_date': end_date, 'limit': limit }
         return self.make_request("GET", path, params=params)
 
-start_date = config['START_DATE']
-end_date = config['END_DATE']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    start_date = config['START_DATE']
+    end_date = config['END_DATE']
 
-compliance_request = ComplianceEventsRequest()
-compliance_events = compliance_request.get_compliance_events(start_date, end_date)
+    compliance_request = ComplianceEventsRequest()
+    compliance_events = compliance_request.get_compliance_events(start_date, end_date)
 
-pprint.pprint(compliance_events)
+    pprint.pprint(compliance_events)

--- a/python/examples/get_document.py
+++ b/python/examples/get_document.py
@@ -21,9 +21,11 @@ class GetDocumentRequest(BaseRequest):
         path = f"/documents/{document_id}"
         return self.make_request("GET", path)
 
-document_id = config['DOCUMENT_ID']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    document_id = config['DOCUMENT_ID']
 
-get_document_request = GetDocumentRequest()
-document = get_document_request.get_document()
+    get_document_request = GetDocumentRequest()
+    document = get_document_request.get_document()
 
-pprint.pprint(document)
+    pprint.pprint(document)

--- a/python/examples/get_document_download.py
+++ b/python/examples/get_document_download.py
@@ -19,9 +19,11 @@ class GetDocumentDownloadRequest(BaseRequest):
         path = f"/documents/{document_id}/download"
         return self.make_request("GET", path)
 
-document_id = config['DOCUMENT_ID']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    document_id = config['DOCUMENT_ID']
 
-get_document_download_request = GetDocumentDownloadRequest()
-document_download = get_document_download_request.get_document_download()
+    get_document_download_request = GetDocumentDownloadRequest()
+    document_download = get_document_download_request.get_document_download()
 
-pprint.pprint(document_download)
+    pprint.pprint(document_download)

--- a/python/examples/get_document_page.py
+++ b/python/examples/get_document_page.py
@@ -21,10 +21,12 @@ class GetDocumentPageRequest(BaseRequest):
         path = f"/documents/{document_id}/page/{page_number}"
         return self.make_request("GET", path)
 
-document_id = config['DOCUMENT_ID']
-page_number = config['PAGE_NUMBER']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    document_id = config['DOCUMENT_ID']
+    page_number = config['PAGE_NUMBER']
 
-get_document_page_request = GetDocumentPageRequest()
-page = get_document_page_request.get_document_page()
+    get_document_page_request = GetDocumentPageRequest()
+    page = get_document_page_request.get_document_page()
 
-pprint.pprint(page)
+    pprint.pprint(page)

--- a/python/examples/get_document_page_url.py
+++ b/python/examples/get_document_page_url.py
@@ -19,10 +19,12 @@ class GetDocumentPageUrlRequest(BaseRequest):
         path = f"/documents/{document_id}/page/{page_number}/url"
         return self.make_request("GET", path)
 
-document_id = config['DOCUMENT_ID']
-page_number = config['PAGE_NUMBER']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    document_id = config['DOCUMENT_ID']
+    page_number = config['PAGE_NUMBER']
 
-get_document_page_url_request = GetDocumentPageUrlRequest()
-url = get_document_page_url_request.get_document_page_url()
+    get_document_page_url_request = GetDocumentPageUrlRequest()
+    url = get_document_page_url_request.get_document_page_url()
 
-pprint.pprint(url)
+    pprint.pprint(url)

--- a/python/examples/get_documents.py
+++ b/python/examples/get_documents.py
@@ -22,9 +22,11 @@ class GetDocumentsRequest(BaseRequest):
         path = "/documents"
         return self.make_request("GET", path, params=params)
 
-status = config['STATUS']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    status = config['STATUS']
 
-get_documents_request = GetDocumentsRequest()
-get_documents_response = get_documents_request.get_documents(status)
+    get_documents_request = GetDocumentsRequest()
+    get_documents_response = get_documents_request.get_documents(status)
 
-pprint.pprint(get_documents_response)
+    pprint.pprint(get_documents_response)

--- a/python/examples/get_documents_bulk_download.py
+++ b/python/examples/get_documents_bulk_download.py
@@ -21,10 +21,12 @@ class GetDocumentsBulkDownloadRequest(BaseRequest):
         }
         return self.make_request('GET', '/documents/bulk-download', params=params)
 
-document_id  = config['DOCUMENT_ID']
-document_ids = [document_id]
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    document_id  = config['DOCUMENT_ID']
+    document_ids = [document_id]
 
-request = GetDocumentsBulkDownloadRequest()
-response = request.bulk_download_documents(document_ids)
+    request = GetDocumentsBulkDownloadRequest()
+    response = request.bulk_download_documents(document_ids)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/get_filing_methods.py
+++ b/python/examples/get_filing_methods.py
@@ -23,11 +23,13 @@ class GetFilingMethodsRequest(BaseRequest):
         }
         return self.make_request('GET', '/filing-methods', params=params)
 
-company_id = config['COMPANY_ID']
-product_id = config['FILING_PRODUCT_ID']
-jurisdiction = config['JURISDICTION']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    company_id = config['COMPANY_ID']
+    product_id = config['FILING_PRODUCT_ID']
+    jurisdiction = config['JURISDICTION']
 
-request = GetFilingMethodsRequest()
-response = request.get_filing_methods(company_id, product_id, jurisdiction)
+    request = GetFilingMethodsRequest()
+    response = request.get_filing_methods(company_id, product_id, jurisdiction)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/get_filing_methods_schemas.py
+++ b/python/examples/get_filing_methods_schemas.py
@@ -22,10 +22,12 @@ class GetFilingMethodsSchemasRequest(BaseRequest):
         }
         return self.make_request('GET', '/filing-methods/schemas', params=params)
 
-company_id = config['COMPANY_ID']
-method_id = config['FILING_METHOD_ID']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    company_id = config['COMPANY_ID']
+    method_id = config['FILING_METHOD_ID']
 
-request = GetFilingMethodsSchemasRequest()
-response = request.get_filing_methods_schemas(company_id, method_id)
+    request = GetFilingMethodsSchemasRequest()
+    response = request.get_filing_methods_schemas(company_id, method_id)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/get_filing_products.py
+++ b/python/examples/get_filing_products.py
@@ -20,10 +20,12 @@ class GetFilingProductsRequest(BaseRequest):
         params = { 'url': url, 'jurisdiction': jurisdiction }
         return self.make_request("GET", path, params=params)
 
-url = config['WEBSITE_URL']
-jurisdiction = config['JURISDICTION']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    url = config['WEBSITE_URL']
+    jurisdiction = config['JURISDICTION']
 
-filing_products_request = GetFilingProductsRequest()
-filing_products = filing_products_request.get_filing_products(url, jurisdiction)
+    filing_products_request = GetFilingProductsRequest()
+    filing_products = filing_products_request.get_filing_products(url, jurisdiction)
 
-pprint.pprint(filing_products)
+    pprint.pprint(filing_products)

--- a/python/examples/get_filing_products_offerings.py
+++ b/python/examples/get_filing_products_offerings.py
@@ -22,10 +22,12 @@ class GetFilingProductsOfferingsRequest(BaseRequest):
         }
         return self.make_request('GET', '/filing-products/offerings', params=params)
 
-company_id = config['COMPANY_ID']
-jurisdiction = config['JURISDICTION']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    company_id = config['COMPANY_ID']
+    jurisdiction = config['JURISDICTION']
 
-request = GetFilingProductsOfferingsRequest()
-response = request.get_filing_products_offerings(company_id, jurisdiction)
+    request = GetFilingProductsOfferingsRequest()
+    response = request.get_filing_products_offerings(company_id, jurisdiction)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/get_invoice.py
+++ b/python/examples/get_invoice.py
@@ -15,13 +15,15 @@ class GetInvoiceRequest(BaseRequest):
     def __init__(self):
         super().__init__()
 
-    def get_invoice(self):
-        path = f"/invoices/{invoice_id}"
+    def get_invoice(self, id):
+        path = f"/invoices/{id}"
         return self.make_request("GET", path)
 
-invoice_id = config['INVOICE_ID']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    invoice_id = config['INVOICE_ID']
 
-get_invoice_request = GetInvoiceRequest()
-invoice = get_invoice_request.get_invoice()
+    get_invoice_request = GetInvoiceRequest()
+    invoice = get_invoice_request.get_invoice(invoice_id )
 
-pprint.pprint(invoice)
+    pprint.pprint(invoice)

--- a/python/examples/get_invoices.py
+++ b/python/examples/get_invoices.py
@@ -23,10 +23,12 @@ class GetInvoicesRequest(BaseRequest):
         }
         return self.make_request('GET', '/invoices', params=params)
 
-company_id  = config['COMPANY_ID']
-company_ids = [company_id]
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    company_id  = config['COMPANY_ID']
+    company_ids = [company_id]
 
-request = GetInvoicesRequest()
-response = request.get_invoices(company_ids)
+    request = GetInvoicesRequest()
+    response = request.get_invoices(company_ids)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/get_order_items_requiring_attention.py
+++ b/python/examples/get_order_items_requiring_attention.py
@@ -21,11 +21,12 @@ class GetOrderItemsRequiringAttentionRequest(BaseRequest):
         }
         return self.make_request('GET', '/order-items/requiring-attention', params=params)
 
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    company_id = config['COMPANY_ID']
+    company_ids = [company_id]
 
-company_id = config['COMPANY_ID']
-company_ids = [company_id]
+    request = GetOrderItemsRequiringAttentionRequest()
+    response = request.get_requiring_attention(company_ids)
 
-request = GetOrderItemsRequiringAttentionRequest()
-response = request.get_requiring_attention(company_ids)
-
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/get_payment_methods.py
+++ b/python/examples/get_payment_methods.py
@@ -18,7 +18,9 @@ class GetPaymentMethodsRequest(BaseRequest):
     def get_payment_methods(self):
         return self.make_request('GET', '/payment-methods')
 
-request = GetPaymentMethodsRequest()
-response = request.get_payment_methods()
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    request = GetPaymentMethodsRequest()
+    response = request.get_payment_methods()
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/get_registered_agent_products.py
+++ b/python/examples/get_registered_agent_products.py
@@ -21,9 +21,11 @@ class GetRegisteredAgentProductsRequest(BaseRequest):
         }
         return self.make_request('GET', '/registered-agent-products', params=params)
 
-website_url = config['WEBSITE_URL']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    website_url = config['WEBSITE_URL']
 
-request = GetRegisteredAgentProductsRequest()
-response = request.get_products(website_url)
+    request = GetRegisteredAgentProductsRequest()
+    response = request.get_products(website_url)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/get_resource.py
+++ b/python/examples/get_resource.py
@@ -18,8 +18,10 @@ class GetResourceRequest(BaseRequest):
     def get_resource(self, resource_id):
         return self.make_request('GET', f'/resources/{resource_id}')
 
-resource_id = config['AGENCY_RESOURCE_ID']
-request = GetResourceRequest()
-response = request.get_resource(resource_id)
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    resource_id = config['AGENCY_RESOURCE_ID']
+    request = GetResourceRequest()
+    response = request.get_resource(resource_id)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/get_resource_page.py
+++ b/python/examples/get_resource_page.py
@@ -18,9 +18,11 @@ class GetResourcePageRequest(BaseRequest):
     def get_resource_page(self, resource_id, page_number):
         return self.make_request('GET', f'/resources/{resource_id}/page/{page_number}')
 
-resource_id = config['AGENCY_RESOURCE_ID']
-page_number = config['PAGE_NUMBER']
-request = GetResourcePageRequest()
-response = request.get_resource_page(resource_id, page_number)
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    resource_id = config['AGENCY_RESOURCE_ID']
+    page_number = config['PAGE_NUMBER']
+    request = GetResourcePageRequest()
+    response = request.get_resource_page(resource_id, page_number)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/get_resources.py
+++ b/python/examples/get_resources.py
@@ -15,7 +15,9 @@ class GetResourcesRequest(BaseRequest):
     def get_resources(self):
         return self.make_request('GET', '/resources')
 
-request = GetResourcesRequest()
-response = request.get_resources()
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    request = GetResourcesRequest()
+    response = request.get_resources()
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/get_resources_download.py
+++ b/python/examples/get_resources_download.py
@@ -21,9 +21,11 @@ class GetResourcesDownloadRequest(BaseRequest):
         path = f"/resources/{resource_id}/download"
         return self.make_request("GET", path)
 
-resource_id = config['AGENCY_RESOURCE_ID']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    resource_id = config['AGENCY_RESOURCE_ID']
 
-request = GetResourcesDownloadRequest()
-response = request.get_resources_download()
+    request = GetResourcesDownloadRequest()
+    response = request.get_resources_download()
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/get_services.py
+++ b/python/examples/get_services.py
@@ -24,12 +24,14 @@ class GetServicesRequest(BaseRequest):
         }
         return self.make_request('GET', '/services', params=params)
 
-company_id  = config['COMPANY_ID']
-company_name  = config['COMPANY_NAME']
-limit = 3
-offset = 0
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    company_id  = config['COMPANY_ID']
+    company_name  = config['COMPANY_NAME']
+    limit = 3
+    offset = 0
 
-request = GetServicesRequest()
-response = request.get_services(company_id, company_name, limit, offset)
+    request = GetServicesRequest()
+    response = request.get_services(company_id, company_name, limit, offset)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/get_services_info.py
+++ b/python/examples/get_services_info.py
@@ -18,9 +18,11 @@ class GetServicesInfoRequest(BaseRequest):
     def get_info(self, service_id):
         return self.make_request('GET', f'/services/{service_id}/info')
 
-service_id = config['SERVICE_ID']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    service_id = config['SERVICE_ID']
 
-request = GetServicesInfoRequest()
-response = request.get_info(service_id)
+    request = GetServicesInfoRequest()
+    response = request.get_info(service_id)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/get_shopping_cart.py
+++ b/python/examples/get_shopping_cart.py
@@ -21,10 +21,12 @@ class GetShoppingCartRequest(BaseRequest):
         }
         return self.make_request('GET', '/shopping-cart', params=params)
 
-company_id  = config['COMPANY_ID']
-company_ids = [company_id]
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    company_id  = config['COMPANY_ID']
+    company_ids = [company_id]
 
-request = GetShoppingCartRequest()
-response = request.get_shopping_cart(company_ids)
+    request = GetShoppingCartRequest()
+    response = request.get_shopping_cart(company_ids)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/get_signed_forms.py
+++ b/python/examples/get_signed_forms.py
@@ -22,10 +22,12 @@ class GetSignedFormsRequest(BaseRequest):
         }
         return self.make_request('GET', '/signed-forms', params=params)
 
-filing_method_id = config['FILING_METHOD_ID']
-website_id  = config['WEBSITE_ID']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    filing_method_id = config['FILING_METHOD_ID']
+    website_id  = config['WEBSITE_ID']
 
-request = GetSignedFormsRequest()
-response = request.get_signed_forms(filing_method_id, website_id)
+    request = GetSignedFormsRequest()
+    response = request.get_signed_forms(filing_method_id, website_id)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/get_simple_products.py
+++ b/python/examples/get_simple_products.py
@@ -21,9 +21,11 @@ class GetSimpleProducts(BaseRequest):
         }
         return self.make_request('GET', '/simple-products', params=params)
 
-website_url  = config['WEBSITE_URL']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    website_url  = config['WEBSITE_URL']
 
-request = GetSimpleProducts()
-response = request.get_products(website_url)
+    request = GetSimpleProducts()
+    response = request.get_products(website_url)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/get_websites.py
+++ b/python/examples/get_websites.py
@@ -21,9 +21,11 @@ class GetWebsites(BaseRequest):
         }
         return self.make_request('GET', '/websites', params=params)
 
-website_url  = config['WEBSITE_URL']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    website_url  = config['WEBSITE_URL']
 
-request = GetWebsites()
-response = request.get_websites(website_url)
+    request = GetWebsites()
+    response = request.get_websites(website_url)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/patch_companies.py
+++ b/python/examples/patch_companies.py
@@ -20,13 +20,15 @@ class PatchCompaniesRequest(BaseRequest):
          body = {'companies': [{'company': company, 'name': name, 'home_state': home_state, 'entity_type': entity_type}]}
          return self.make_request("PATCH", path, body=body)
 
-#  this example will update the company name, home_state, and entity_type
-company = config['COMPANY_NAME']
-name = 'The Best Fake Company'
-home_state = 'Arizona'
-entity_type = 'Corporation'
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    #  this example will update the company name, home_state, and entity_type
+    company = config['COMPANY_NAME']
+    name = 'The Best Fake Company'
+    home_state = 'Arizona'
+    entity_type = 'Corporation'
 
-patch_companies_request = PatchCompaniesRequest()
-patch_companies_response = patch_companies_request.patch_companies(company, name, home_state, entity_type)
+    patch_companies_request = PatchCompaniesRequest()
+    patch_companies_response = patch_companies_request.patch_companies(company, name, home_state, entity_type)
 
-pprint.pprint(patch_companies_response)
+    pprint.pprint(patch_companies_response)

--- a/python/examples/patch_payment_methods.py
+++ b/python/examples/patch_payment_methods.py
@@ -45,8 +45,10 @@ class PatchPaymentMethodsRequest(BaseRequest):
         path = f'/payment-methods/{payment_method_id}'
         return self.make_request('PATCH', path, body=body)
 
-payment_method_id = config['PAYMENT_METHOD_ID']
-request = PatchPaymentMethodsRequest()
-response = request.patch_payment_methods(payment_method_id)
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    payment_method_id = config['PAYMENT_METHOD_ID']
+    request = PatchPaymentMethodsRequest()
+    response = request.patch_payment_methods(payment_method_id)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/post_callbacks.py
+++ b/python/examples/post_callbacks.py
@@ -20,9 +20,11 @@ class PostCallbacksRequest(BaseRequest):
         body = { 'url': url }
         return self.make_request("POST", path, body=body)
 
-url = config['CALLBACK_URL']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    url = config['CALLBACK_URL']
 
-post_callbacks_request = PostCallbacksRequest()
-post_callbacks_response = post_callbacks_request.post_callbacks(url)
+    post_callbacks_request = PostCallbacksRequest()
+    post_callbacks_response = post_callbacks_request.post_callbacks(url)
 
-pprint.pprint(post_callbacks_response)
+    pprint.pprint(post_callbacks_response)

--- a/python/examples/post_companies.py
+++ b/python/examples/post_companies.py
@@ -20,11 +20,13 @@ class PostCompaniesRequest(BaseRequest):
         body = {'companies': [{'name': name, 'home_state': home_state, 'entity_type': entity_type}]}
         return self.make_request("POST", path, body=body)
 
-name = config['COMPANY_NAME']
-home_state = config['JURISDICTION']
-entity_type = config['ENTITY_TYPE']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    name = config['COMPANY_NAME']
+    home_state = config['JURISDICTION']
+    entity_type = config['ENTITY_TYPE']
 
-post_companies_request = PostCompaniesRequest()
-post_companies_response = post_companies_request.post_companies(name, home_state, entity_type)
+    post_companies_request = PostCompaniesRequest()
+    post_companies_response = post_companies_request.post_companies(name, home_state, entity_type)
 
-pprint.pprint(post_companies_response)
+    pprint.pprint(post_companies_response)

--- a/python/examples/post_invoices_pay.py
+++ b/python/examples/post_invoices_pay.py
@@ -23,10 +23,12 @@ class PostInvoicesPayRequest(BaseRequest):
         }
         return self.make_request("POST", path, body=body)
 
-payment_method_id = config['PAYMENT_METHOD_ID']
-invoice_ids = config['INVOICE_ID']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    payment_method_id = config['PAYMENT_METHOD_ID']
+    invoice_ids = config['INVOICE_ID']
 
-post_invoices_pay_request = PostInvoicesPayRequest()
-post_invoices_pay_response = post_invoices_pay_request.post_invoices_pay(payment_method_id, invoice_ids)
+    post_invoices_pay_request = PostInvoicesPayRequest()
+    post_invoices_pay_response = post_invoices_pay_request.post_invoices_pay(payment_method_id, invoice_ids)
 
-pprint.pprint(post_invoices_pay_response)
+    pprint.pprint(post_invoices_pay_response)

--- a/python/examples/post_order_items_requiring_attention.py
+++ b/python/examples/post_order_items_requiring_attention.py
@@ -24,15 +24,16 @@ class PostOrderItemsRequiringAttentionRequest(BaseRequest):
         }
         return self.make_request('POST', '/order-items/requiring-attention', body=body)
 
-ORDER_ITEM_ID = config['ORDER_ITEM_ID']
-COMPANY_ID = config['COMPANY_ID']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    ORDER_ITEM_ID = config['ORDER_ITEM_ID']
+    COMPANY_ID = config['COMPANY_ID']
+    cwd = os.getcwd();
+    file_path = f"{cwd}/../data/form_data_ein_tax_id.json";
 
-cwd = os.getcwd();
-file_path = f"{cwd}/../data/form_data.json";
-
-with open(file_path, 'r') as file:
-    FORM_DATA = json.load(file)
-    print(f"form_data: {FORM_DATA}\n")
-    request = PostOrderItemsRequiringAttentionRequest()
-    response = request.post_requring_attention(COMPANY_ID, ORDER_ITEM_ID, FORM_DATA)
-    pprint.pprint(response)
+    with open(file_path, 'r') as file:
+        FORM_DATA = json.load(file)
+        print(f"form_data: {FORM_DATA}\n")
+        request = PostOrderItemsRequiringAttentionRequest()
+        response = request.post_requring_attention(COMPANY_ID, ORDER_ITEM_ID, FORM_DATA)
+        pprint.pprint(response)

--- a/python/examples/post_payment_methods.py
+++ b/python/examples/post_payment_methods.py
@@ -40,11 +40,12 @@ class PostPaymentMethodsRequest(BaseRequest):
     def __init__(self):
         super().__init__()
     
-    def post_payment_methods(self):
-        body = PAYMENT_METHOD
-        return self.make_request('POST', '/payment-methods', body=body)
+    def post_payment_methods(self, payment_card_info):
+        return self.make_request('POST', '/payment-methods', body=payment_card_info)
 
-request = PostPaymentMethodsRequest()
-response = request.post_payment_methods()
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    request = PostPaymentMethodsRequest()
+    response = request.post_payment_methods(PAYMENT_METHOD)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/post_services.py
+++ b/python/examples/post_services.py
@@ -23,11 +23,13 @@ class PostServicesRequest(BaseRequest):
         }
         return self.make_request('POST', '/services', body=body)
 
-company_id = config['COMPANY_ID'];
-company_name = config['COMPANY_NAME'];
-jurisdiction_id = config['JURISDICTION_ID'];
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    company_id = config['COMPANY_ID'];
+    company_name = config['COMPANY_NAME'];
+    jurisdiction_id = config['JURISDICTION_ID'];
 
-request = PostServicesRequest()
-response = request.post_services(company_id, company_name, jurisdiction_id)
+    request = PostServicesRequest()
+    response = request.post_services(company_id, company_name, jurisdiction_id)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/post_services_cancel_request.py
+++ b/python/examples/post_services_cancel_request.py
@@ -18,8 +18,10 @@ class PostServicesCancelRequest(BaseRequest):
     def post_cancel(self, service_id):
         return self.make_request('POST', f'/services/{service_id}/cancel-request')
 
-service_id = config['SERVICE_ID'];
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    service_id = config['SERVICE_ID'];
 
-request = PostServicesCancelRequest()
-response = request.post_cancel(service_id)
-pprint.pprint(response)
+    request = PostServicesCancelRequest()
+    response = request.post_cancel(service_id)
+    pprint.pprint(response)

--- a/python/examples/post_services_info.py
+++ b/python/examples/post_services_info.py
@@ -19,12 +19,14 @@ class PostServicesInfoRequest(BaseRequest):
     def post_info(self, service_id, service_info):
         return self.make_request('POST', f'/services/{service_id}/info', body=service_info)
 
-service_id = config['SERVICE_ID'];
-cwd = os.getcwd();
-file_path = f"{cwd}/../data/services/add_info_corp.json";
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    service_id = config['SERVICE_ID'];
+    cwd = os.getcwd();
+    file_path = f"{cwd}/../data/services/add_info_corp.json";
 
-with open(file_path, 'r') as file:
-    service_info = json.load(file)
-    request = PostServicesInfoRequest()
-    response = request.post_info(service_id, service_info)
-    pprint.pprint(response)
+    with open(file_path, 'r') as file:
+        service_info = json.load(file)
+        request = PostServicesInfoRequest()
+        response = request.post_info(service_id, service_info)
+        pprint.pprint(response)

--- a/python/examples/post_shopping_cart.py
+++ b/python/examples/post_shopping_cart.py
@@ -24,13 +24,15 @@ class PostShoppingCartRequest(BaseRequest):
         }
         return self.make_request('POST', '/shopping-cart', body=body)
 
-company_id = config['COMPANY_ID'];
-filing_product_id = config['FILING_PRODUCT_ID'];
-filing_method_id  = config['FILING_METHOD_ID'];
-quantity = 1;
-# form_data = {}; # optional, expects JSON mapping to fields of filing method schema
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    company_id = config['COMPANY_ID'];
+    filing_product_id = config['FILING_PRODUCT_ID'];
+    filing_method_id  = config['FILING_METHOD_ID'];
+    quantity = 1;
+    # form_data = {}; # optional, expects JSON mapping to fields of filing method schema
 
-request = PostShoppingCartRequest()
-response = request.post_shopping_cart(company_id, filing_product_id, filing_method_id, quantity)
+    request = PostShoppingCartRequest()
+    response = request.post_shopping_cart(company_id, filing_product_id, filing_method_id, quantity)
 
-pprint.pprint(response)
+    pprint.pprint(response)

--- a/python/examples/post_shopping_cart_checkout.py
+++ b/python/examples/post_shopping_cart_checkout.py
@@ -23,11 +23,13 @@ class PostShoppingCartCheckoutRequest(BaseRequest):
         }
         return self.make_request('POST', '/shopping-cart/checkout', body=body)
 
-company_id = config['COMPANY_ID']
-item_id = config['SHOPPING_CART_ITEM_ID']
-payment_method_id = config['PAYMENT_METHOD_ID']
+# run as standalone script by passing any command line argument
+if len(sys.argv) > 1:
+    company_id = config['COMPANY_ID']
+    item_id = config['SHOPPING_CART_ITEM_ID']
+    payment_method_id = config['PAYMENT_METHOD_ID']
 
-request = PostShoppingCartCheckoutRequest()
-response = request.post_checkout(company_id, item_id, payment_method_id)
+    request = PostShoppingCartCheckoutRequest()
+    response = request.post_checkout(company_id, item_id, payment_method_id)
 
-pprint.pprint(response)
+    pprint.pprint(response)


### PR DESCRIPTION
end-to-end example of EIN tax id checkout in Python
- Had to prevent examples/ script from running on module load when reusing their classes in end-to-end script
- solution I chose was any arbitrary command line argument when the examples/ script are run in "standalone" mode
- e.g. python3 examples/<script-name> <standalone-arg>